### PR TITLE
Add donejs

### DIFF
--- a/library/donejs
+++ b/library/donejs
@@ -1,13 +1,9 @@
 # maintainer: DoneJS Team <https://github.com/donejs/docker-donejs> (@donejs)
 
-0.10: git://github.com/donejs/docker-donejs@COMMIT 0.10
+0.5: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.5
 
-0.10-slim: git://github.com/donejs/docker-donejs@COMMIT 0.10/slim
+0.5-slim: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.5/slim
 
-0.12: git://github.com/donejs/docker-donejs@COMMIT 0.12
+0.6: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.6
 
-0.12-slim: git://github.com/donejs/docker-donejs@COMMIT 0.12/slim
-
-4: git://github.com/donejs/docker-donejs@COMMIT 4.2
-
-4-slim: git://github.com/donejs/docker-donejs@COMMIT 4.2/slim
+0.6-slim: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.6/slim

--- a/library/donejs
+++ b/library/donejs
@@ -4,6 +4,6 @@
 
 0.5-slim: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.5/slim
 
-0.6: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.6
+0.6: git://github.com/donejs/docker-donejs@75bbd1caf861390dfe02837b1d71e582fa60e04e 0.6
 
-0.6-slim: git://github.com/donejs/docker-donejs@22c5ec573b10dadcdf074b02f29b094543b4fb6b 0.6/slim
+0.6-slim: git://github.com/donejs/docker-donejs@75bbd1caf861390dfe02837b1d71e582fa60e04e 0.6/slim

--- a/library/donejs
+++ b/library/donejs
@@ -1,0 +1,13 @@
+# maintainer: DoneJS Team <https://github.com/donejs/docker-donejs> (@donejs)
+
+0.10: git://github.com/donejs/docker-donejs@COMMIT 0.10
+
+0.10-slim: git://github.com/donejs/docker-donejs@COMMIT 0.10/slim
+
+0.12: git://github.com/donejs/docker-donejs@COMMIT 0.12
+
+0.12-slim: git://github.com/donejs/docker-donejs@COMMIT 0.12/slim
+
+4: git://github.com/donejs/docker-donejs@COMMIT 4.2
+
+4-slim: git://github.com/donejs/docker-donejs@COMMIT 4.2/slim


### PR DESCRIPTION
Adding DoneJS docker files to public repository. This allows anyone to install DoneJS from their docker file using the `FROM` directive instead of having to install it manually.
